### PR TITLE
do not replace default_backend at startup

### DIFF
--- a/haproxy.template
+++ b/haproxy.template
@@ -25,7 +25,11 @@ listen stats
 
 frontend web-app
   bind *:80
+  {{if key "backend/current"}}
   default_backend {{key "backend/current"}}
+  {{else}}
+  default_backend default
+  {{end}}
 
 backend default
   server s1 localhost:8080

--- a/startup.sh
+++ b/startup.sh
@@ -12,8 +12,6 @@ sed -i -e "s/webapp/${SERVICE_TAG}/g" $TEMPLATE
 
 haproxy -f "$CONFIG_FILE" -p "$PIDFILE" -D -st $(cat $PIDFILE)
 
-current=$(curl -X GET ${CONSUL_PORT_8500_TCP_ADDR:-172.17.42.1}:${CONSUL_PORT_8500_TCP_PORT:-8500}/v1/kv/backend/current)
-[[ -z "$current" ]] && sed -i -e "s/default_backend.*$/default_backend default/" $TEMPLATE
 
 env
 


### PR DESCRIPTION
A default_backend is set a value "default" in haproxy.template when a request for "backend/current" from consul key/value was empty at startup.sh. However it is sometimes hard to prepare consul and default "backend/current" value, for example, if you are using docker-compose.
